### PR TITLE
Change to account for API Controller refractor

### DIFF
--- a/src/components/views/Dashboard.js
+++ b/src/components/views/Dashboard.js
@@ -55,7 +55,7 @@ const Dashboard = () => {
     // effect callbacks are synchronous to prevent race conditions. So we put the async function inside:
     async function fetchData() {
       try {
-            const response = await api.get('/users', headers);
+            const response = await api.get('/users', headers());
 
         // delays continuous execution of an async operation for 1 second.
         // This is just a fake async call, so that the spinner can be displayed

--- a/src/components/views/EditProfile.js
+++ b/src/components/views/EditProfile.js
@@ -44,7 +44,7 @@ const EditProfile = (props) => {
     // effect callbacks are synchronous to prevent race conditions. So we put the async function inside:
     async function fetchData() {
       try {
-        const response = await api.get('/users/' + id, headers);
+        const response = await api.get('/users/' + id, headers());
 
         setUser(response.data[0]);
         setUsername(response.data[0].username);
@@ -76,7 +76,7 @@ const EditProfile = (props) => {
         requestBody = JSON.stringify({ username });
 
       }
-      const response = await api.put('/users/' + id, requestBody, headers);
+      const response = await api.put('/users/' + id, requestBody, headers());
       console.log(response.status);
       history.push(`/profile/` + id);
 

--- a/src/components/views/GameRoom.js
+++ b/src/components/views/GameRoom.js
@@ -39,7 +39,7 @@ function reducer(state, action) {
 }
 
 async function getTopics(){
-    const response = await api.get("/categories", headers)
+    const response = await api.get("/categories", headers())
     console.log("Response for api call /categories: ",response.data)
     response.data.forEach(element => {
         const topic = {
@@ -55,16 +55,16 @@ async function getTopics(){
 
 const gameMode = [
     {
-        name: 'standard',
-        value: 'standard',
+        name: 'easy',
+        value: 'easy',
     },
     {
-        name: 'time tells',
-        value: 'time tells',
+        name: 'medium',
+        value: 'medium',
     },
     {
-        name: 'trust or bust',
-        value: 'trust or bust',
+        name: 'hard',
+        value: 'hard',
     },
 ]
 
@@ -117,8 +117,8 @@ const GameRoom = props => {
             })
             console.log(requestBody)
 
-            const response = await api.post('/createRoom', requestBody, headers)
-            console.log('headers', headers)
+            const response = await api.post('/createRoom', requestBody, headers())
+            console.log('headers()', headers())
             //put the roomCode into localStorage for later use
             const roomCode = response.data.roomCode.toString()
             
@@ -132,13 +132,6 @@ const GameRoom = props => {
             //server call via socketio to join the namespace (would join the GameRoom as well, but this is the Leader anyways, who's already joined the GameRoom when they created it
             const userId = localStorage.getItem("userId");
             const bearerToken = localStorage.getItem("token");
-
-            const response2 = await api.get(`/questions/?roomCode=${response.data.roomCode}`, headers)
-            
-            //alternative request in case of troubles:
-            //const response2 = await api.get('/questions/?roomCode', headers)
-            
-            console.log("Response for api call /questions: ",response2.data)
 
 
             socket.emit('join_room', {
@@ -176,7 +169,7 @@ const GameRoom = props => {
                                 key: 'topic',
                             })} />
                 </SettingsContainer>
-                <SettingsContainer title="Choose a game mode:">
+                <SettingsContainer title="Choose a difficulty:">
                     <RadioButtons
                         name="gamemode"
                         items={gameMode}

--- a/src/components/views/Profile.js
+++ b/src/components/views/Profile.js
@@ -44,7 +44,7 @@ const ShowProfile = (props) => {
     // effect callbacks are synchronous to prevent race conditions. So we put the async function inside:
     async function fetchData() {
       try {
-        const response = await api.get('/users/' + id, headers);
+        const response = await api.get('/users/' + id, headers());
 
         // Get the returned user and update a new object.
 

--- a/src/components/views/WaitingRoom.js
+++ b/src/components/views/WaitingRoom.js
@@ -32,7 +32,7 @@ const WaitingRoom = (props) => {
 
     const startGame = async () => {
         console.log("socket acknowledged as connected pressing start:", socket.connected);
-        //const response2 = await api.get('/questions/?roomCode={roomCode}', headers)
+        //const response2 = await api.get('/questions/?roomCode={roomCode}', headers())
         //console.log("Response for api call /questions: ",response2.data)
         // add a condition that only the leader can click this
         // socket.emit('start_game',{
@@ -50,7 +50,7 @@ const WaitingRoom = (props) => {
 
     useEffect(async () =>{
         console.log("socket acknowledged as connected:", socket.connected);
-        // const response2 = await api.get('/questions/?roomCode={roomCode}', headers)
+        // const response2 = await api.get('/questions/?roomCode={roomCode}', headers())
         // console.log("Response for api call /questions: ",response2.data)
         //infos oming from backend
         //returns a list of members since that is the only thing in the state that changes
@@ -66,7 +66,7 @@ const WaitingRoom = (props) => {
         //     history.push(`/question`);
         // })
 
-        socket.on("get_Question", (incomingData) =>{
+        socket.on("get_question", (incomingData) =>{
             console.log("question arrived", incomingData);
             history.push(`/question`);
         })

--- a/src/components/views/WelcomePage.js
+++ b/src/components/views/WelcomePage.js
@@ -24,8 +24,8 @@ const WelcomePage = props => {
     }
 
     const logout = () => {
-        localStorage.clear();
         logoutRequest(history);
+        
     }
 
 

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -34,8 +34,12 @@ export const handleError = error => {
   }
 };
 
-export const headers = {
-  headers: {
-    Authorization: `Bearer ${localStorage.getItem('token')}`
-  }
+export function headers() {
+  var token = localStorage.getItem('token');
+  return {
+    headers:{
+      Authorization: `Bearer ${token}`
+    }
+  };
+  
 };

--- a/src/helpers/axios.js
+++ b/src/helpers/axios.js
@@ -1,9 +1,9 @@
 import { api, headers } from 'helpers/api';
 
 const logoutRequest = async (history) => {
-
-    api.get('/logout', headers).then(() => {
-        localStorage.removeItem('token');
+    
+    api.get('/logout', headers()).then(() => {
+        localStorage.clear();
         history.push("/login");
 
     })


### PR DESCRIPTION
removed all calls to /questions as the endpoint no longer exists questions are now generated and stored in the gameRoom entity right upon creation of a GameRoom Also fixed, the header issue noticed by Dario
closes #37 